### PR TITLE
defaults: remove trailing slash in userli_home

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ userli_mysql_db: "userli"
 userli_mysql_priv: "{{ userli_mysql_db }}.*:ALL"
 userli_db_type: mysql
 userli_db_url: "{{ userli_db_type }}://{{ userli_mysql_user }}:{{ userli_mysql_password }}@127.0.0.1:3306/{{ userli_mysql_db }}"
-userli_home: "/var/www/"
+userli_home: "/var/www"
 userli_user: "www-data"
 userli_group: "{{ userli_user }}"
 userli_symfony_path: "{{ userli_home }}/userli"


### PR DESCRIPTION
Currently the merged path defaults to `/var/www//userli`